### PR TITLE
feat: logs user or org id to console when org name or user is clicked

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy to GitHub Pages
 
 "on":
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,12 +8,48 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  pages: write
+  id-token: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - id: release
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  deploy:
+    name: Deploy release tag to GitHub Pages
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: 'dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ feat!: remove legacy org endpoint
 - Runs on push to `main`.
 - Uses Conventional Commit history to determine semantic version bump.
 - Opens or updates a release PR with version/changelog updates.
-- This repo is configured to only manage release PR/changelog flow and not publish GitHub Releases.
+- When the release PR is merged, it creates a Git tag and GitHub Release.
+- GitHub Pages deployment is triggered from that release tag (one deploy per release).
 
 Version bump rules:
 
@@ -152,9 +153,12 @@ This project is ready for static hosting (e.g., GitHub Pages, Netlify, Vercel).
 
 ### Deploy to GitHub Pages
 
-1. Push to the `main` branch.
-2. GitHub Actions workflow in `.github/workflows/deploy.yml` will build and deploy to Pages automatically.
-3. Ensure the `base` option in `vite.config.ts` is set to `'./'` for correct asset paths.
+1. Merge regular work into `main`.
+2. Release Please opens/updates a release PR.
+3. Merge the release PR to create a Git tag and GitHub Release.
+4. The release workflow builds and deploys GitHub Pages from that tag.
+5. Optional: run `.github/workflows/deploy.yml` manually to redeploy current code.
+6. Ensure the `base` option in `vite.config.ts` is set to `'./'` for correct asset paths.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This project is ready for static hosting (e.g., GitHub Pages, Netlify, Vercel).
 
 ## Troubleshooting
 
-- **API errors locally**: Make sure your backend is running at `localhost:3000` and supports the `/v1/org-chart` endpoint.
+- **API errors locally**: By default, local development uses `https://api.f3nation.com/v1`. To target a local backend, set `VITE_API_BASE` (for example `http://localhost:3000/v1`) in your `.env` file.
 - **Module not found errors**: Run `npm install` to ensure all dependencies are installed.
 - **Type errors for Vitest**: Ensure `vitest` is installed as a dev dependency.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ An interactive map application for visualizing F3 Nation's sectors, areas, regio
 
 The API base URL is set automatically:
 
-- **Local development**: Uses `http://localhost:3000/v1` (see proxy config in vite.config.ts)
+- **Local development**: Defaults to `https://api.f3nation.com/v1` unless `VITE_API_BASE` is set.
 - **Production (GitHub Pages, etc.)**: Uses `https://api.f3nation.com/v1`
 - You can override this by setting the `VITE_API_BASE` environment variable in a `.env` file:
   ```env

--- a/src/main.ts
+++ b/src/main.ts
@@ -595,7 +595,7 @@ function renderInfo(org: Org, detail?: OrgInfo) {
     }
   }
   const emailDisplay = detail?.email 
-    ? `<a href="mailto:${detail.email}" class="info-link">${detail.email}</a>`
+    ? `<a href="mailto:${encodeURIComponent(detail.email)}" class="info-link">${escapeHtml(detail.email)}</a>`
     : 'Not listed'
   
   const socialLinks: string[] = []
@@ -627,11 +627,14 @@ function renderInfo(org: Org, detail?: OrgInfo) {
           const title = pos.title ?? 'Leader'
           const name = pos.f3Name ?? 'Unknown'
           const avatar = pos.avatarUrl ?? UNKNOWN_AVATAR_SVG
-          const avatarMarkup = `<img src="${avatar}" alt="${name}" class="info-avatar" loading="lazy" />`
+          const safeTitle = escapeHtml(title)
+          const safeName = escapeHtml(name)
+          const safeAvatar = escapeHtml(avatar)
+          const avatarMarkup = `<img src="${safeAvatar}" alt="${safeName}" class="info-avatar" loading="lazy" />`
           const adminLogAttr = showAdminDebug
             ? ` data-admin-log="${encodeAdminLog({ positionId: pos.positionId, userId: pos.userId, f3Name: name })}"`
             : ''
-          return `<li class="info-position"${adminLogAttr}>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
+          return `<li class="info-position"${adminLogAttr}>${avatarMarkup}<div><div class="info-role">${safeTitle}</div><div class="info-person">${safeName}</div></div></li>`
         })
         .join('')
     : '<li class="info-empty">No positions listed.</li>'
@@ -642,22 +645,27 @@ function renderInfo(org: Org, detail?: OrgInfo) {
           const title = role.title ?? 'Role'
           const name = role.f3Name ?? 'Unknown'
           const avatar = role.avatarUrl ?? UNKNOWN_AVATAR_SVG
-          const avatarMarkup = `<img src="${avatar}" alt="${name}" class="info-avatar" loading="lazy" />`
+          const safeTitle = escapeHtml(title)
+          const safeName = escapeHtml(name)
+          const safeAvatar = escapeHtml(avatar)
+          const avatarMarkup = `<img src="${safeAvatar}" alt="${safeName}" class="info-avatar" loading="lazy" />`
           const adminLogAttr = showAdminDebug
             ? ` data-admin-log="${encodeAdminLog({ roleId: role.roleId, userId: role.userId, f3Name: name })}"`
             : ''
-          return `<li class="info-position"${adminLogAttr}>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
+          return `<li class="info-position"${adminLogAttr}>${avatarMarkup}<div><div class="info-role">${safeTitle}</div><div class="info-person">${safeName}</div></div></li>`
         })
         .join('')
     : '<li class="info-empty">No roles listed.</li>'
 
+  const displayName = escapeHtml(detail?.name ?? org.name)
+  const displayOrgType = escapeHtml((detail?.orgType ?? org.orgType).toUpperCase())
   const orgAdminLogAttr = showAdminDebug
     ? ` data-admin-log="${encodeAdminLog({ orgId: detail?.id ?? org.id, name: detail?.name ?? org.name, orgType: detail?.orgType ?? org.orgType })}"`
     : ''
 
   infoPanel.innerHTML = `
-    <div class="info-title"${orgAdminLogAttr}>${detail?.name ?? org.name}</div>
-    <div class="info-subtitle">${(detail?.orgType ?? org.orgType).toUpperCase()}</div>
+    <div class="info-title"${orgAdminLogAttr}>${displayName}</div>
+    <div class="info-subtitle">${displayOrgType}</div>
     <div class="info-section">
       <div class="info-label">Organization Email</div>
       <div class="info-value">${emailDisplay}</div>
@@ -698,15 +706,17 @@ function renderInfo(org: Org, detail?: OrgInfo) {
 }
 
 function renderPlaceholder(message: string) {
+  const safeMessage = escapeHtml(message)
   infoPanel.innerHTML = `
-    <div class="info-title">${message}</div>
+    <div class="info-title">${safeMessage}</div>
     <div class="info-body"></div>
   `
 }
 
 function renderLoadingInfo(org: Org) {
+  const safeName = escapeHtml(org.name)
   infoPanel.innerHTML = `
-    <div class="info-title">${org.name}</div>
+    <div class="info-title">${safeName}</div>
     <div class="info-body">Loadings...</div>
   `
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,12 +20,16 @@ import { updateUrlState, restoreStateFromUrl, levelOrder, currentLevelIndex, sel
 declare const __APP_VERSION__: string
 
 type OrgPosition = {
+  positionId?: number
+  userId?: number
   title?: string
   f3Name?: string
   avatarUrl?: string
 }
 
 type OrgRole = {
+  roleId?: number
+  userId?: number
   title?: string
   f3Name?: string
   avatarUrl?: string
@@ -129,6 +133,17 @@ L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
 
 const layerGroup = L.layerGroup().addTo(map)
 const infoPanel = document.querySelector<HTMLDivElement>('#info')!
+infoPanel.addEventListener('click', (e) => {
+  const target = (e.target as HTMLElement).closest<HTMLElement>('[data-admin-log]')
+  if (!target) return
+  const raw = target.dataset.adminLog
+  if (!raw) return
+  try {
+    console.log('[admin]', JSON.parse(raw))
+  } catch {
+    console.log('[admin]', raw)
+  }
+})
 const breadcrumbEl = document.querySelector<HTMLDivElement>('#breadcrumb')!
 const layersContainer = document.querySelector<HTMLDivElement>('#layers')!
 const mapLoadingEl = document.querySelector<HTMLDivElement>('#map-loading')!
@@ -594,7 +609,8 @@ function renderInfo(org: Org, detail?: OrgInfo) {
           const name = pos.f3Name ?? 'Unknown'
           const avatar = pos.avatarUrl ?? UNKNOWN_AVATAR_SVG
           const avatarMarkup = `<img src="${avatar}" alt="${name}" class="info-avatar" loading="lazy" />`
-          return `<li class="info-position">${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
+          const log = JSON.stringify({ positionId: pos.positionId, userId: pos.userId, f3Name: name })
+          return `<li class="info-position" data-admin-log='${log}'>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
         })
         .join('')
     : '<li class="info-empty">No positions listed.</li>'
@@ -606,13 +622,14 @@ function renderInfo(org: Org, detail?: OrgInfo) {
           const name = role.f3Name ?? 'Unknown'
           const avatar = role.avatarUrl ?? UNKNOWN_AVATAR_SVG
           const avatarMarkup = `<img src="${avatar}" alt="${name}" class="info-avatar" loading="lazy" />`
-          return `<li class="info-position">${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
+          const log = JSON.stringify({ roleId: role.roleId, userId: role.userId, f3Name: name })
+          return `<li class="info-position" data-admin-log='${log}'>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
         })
         .join('')
     : '<li class="info-empty">No roles listed.</li>'
 
   infoPanel.innerHTML = `
-    <div class="info-title">${detail?.name ?? org.name}</div>
+    <div class="info-title" data-admin-log='${JSON.stringify({ orgId: detail?.id ?? org.id, name: detail?.name ?? org.name, orgType: detail?.orgType ?? org.orgType })}'>${detail?.name ?? org.name}</div>
     <div class="info-subtitle">${(detail?.orgType ?? org.orgType).toUpperCase()}</div>
     <div class="info-section">
       <div class="info-label">Organization Email</div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,11 @@ import { updateUrlState, restoreStateFromUrl, levelOrder, currentLevelIndex, sel
 
 declare const __APP_VERSION__: string
 
+type AdminFlagsWindow = Window & {
+  __IS_ADMIN__?: boolean
+  __IS_DEBUG__?: boolean
+}
+
 type OrgPosition = {
   positionId?: number
   userId?: number
@@ -133,17 +138,31 @@ L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
 
 const layerGroup = L.layerGroup().addTo(map)
 const infoPanel = document.querySelector<HTMLDivElement>('#info')!
-infoPanel.addEventListener('click', (e) => {
-  const target = (e.target as HTMLElement).closest<HTMLElement>('[data-admin-log]')
-  if (!target) return
-  const raw = target.dataset.adminLog
-  if (!raw) return
-  try {
-    console.log('[admin]', JSON.parse(raw))
-  } catch {
-    console.log('[admin]', raw)
-  }
-})
+
+function isAdminUser(): boolean {
+  const flags = window as AdminFlagsWindow
+  return flags.__IS_ADMIN__ === true || flags.__IS_DEBUG__ === true
+}
+
+const showAdminDebug = isAdminUser()
+
+function encodeAdminLog(payload: unknown): string {
+  return encodeURIComponent(JSON.stringify(payload))
+}
+
+if (showAdminDebug) {
+  infoPanel.addEventListener('click', (e) => {
+    const target = (e.target as HTMLElement).closest<HTMLElement>('[data-admin-log]')
+    if (!target) return
+    const raw = target.dataset.adminLog
+    if (!raw) return
+    try {
+      console.log('[admin]', JSON.parse(decodeURIComponent(raw)))
+    } catch {
+      console.log('[admin]', raw)
+    }
+  })
+}
 const breadcrumbEl = document.querySelector<HTMLDivElement>('#breadcrumb')!
 const layersContainer = document.querySelector<HTMLDivElement>('#layers')!
 const mapLoadingEl = document.querySelector<HTMLDivElement>('#map-loading')!
@@ -609,8 +628,10 @@ function renderInfo(org: Org, detail?: OrgInfo) {
           const name = pos.f3Name ?? 'Unknown'
           const avatar = pos.avatarUrl ?? UNKNOWN_AVATAR_SVG
           const avatarMarkup = `<img src="${avatar}" alt="${name}" class="info-avatar" loading="lazy" />`
-          const log = JSON.stringify({ positionId: pos.positionId, userId: pos.userId, f3Name: name })
-          return `<li class="info-position" data-admin-log='${log}'>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
+          const adminLogAttr = showAdminDebug
+            ? ` data-admin-log="${encodeAdminLog({ positionId: pos.positionId, userId: pos.userId, f3Name: name })}"`
+            : ''
+          return `<li class="info-position"${adminLogAttr}>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
         })
         .join('')
     : '<li class="info-empty">No positions listed.</li>'
@@ -622,14 +643,20 @@ function renderInfo(org: Org, detail?: OrgInfo) {
           const name = role.f3Name ?? 'Unknown'
           const avatar = role.avatarUrl ?? UNKNOWN_AVATAR_SVG
           const avatarMarkup = `<img src="${avatar}" alt="${name}" class="info-avatar" loading="lazy" />`
-          const log = JSON.stringify({ roleId: role.roleId, userId: role.userId, f3Name: name })
-          return `<li class="info-position" data-admin-log='${log}'>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
+          const adminLogAttr = showAdminDebug
+            ? ` data-admin-log="${encodeAdminLog({ roleId: role.roleId, userId: role.userId, f3Name: name })}"`
+            : ''
+          return `<li class="info-position"${adminLogAttr}>${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
         })
         .join('')
     : '<li class="info-empty">No roles listed.</li>'
 
+  const orgAdminLogAttr = showAdminDebug
+    ? ` data-admin-log="${encodeAdminLog({ orgId: detail?.id ?? org.id, name: detail?.name ?? org.name, orgType: detail?.orgType ?? org.orgType })}"`
+    : ''
+
   infoPanel.innerHTML = `
-    <div class="info-title" data-admin-log='${JSON.stringify({ orgId: detail?.id ?? org.id, name: detail?.name ?? org.name, orgType: detail?.orgType ?? org.orgType })}'>${detail?.name ?? org.name}</div>
+    <div class="info-title"${orgAdminLogAttr}>${detail?.name ?? org.name}</div>
     <div class="info-subtitle">${(detail?.orgType ?? org.orgType).toUpperCase()}</div>
     <div class="info-section">
       <div class="info-label">Organization Email</div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -717,7 +717,7 @@ function renderLoadingInfo(org: Org) {
   const safeName = escapeHtml(org.name)
   infoPanel.innerHTML = `
     <div class="info-title">${safeName}</div>
-    <div class="info-body">Loadings...</div>
+    <div class="info-body">Loading ...</div>
   `
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,10 @@
 import { defineConfig, loadEnv } from 'vite'
 
 export default defineConfig(({ mode }) => {
-  // Load env file based on mode
   const env = loadEnv(mode, process.cwd(), '');
   const appVersion = process.env.npm_package_version ?? '0.0.0';
   return {
     base: './',
-    server: {
-      proxy: {
-        '/v1/org-chart': env.VITE_API_BASE?.includes('localhost')
-          ? 'http://localhost:3000'
-          : 'https://api.f3nation.com'
-      }
-    },
     define: {
       'import.meta.env.VITE_API_BASE': JSON.stringify(env.VITE_API_BASE),
       __APP_VERSION__: JSON.stringify(appVersion)


### PR DESCRIPTION
This pull request adds enhanced admin logging capabilities to the organization info UI and cleans up the Vite configuration. The main focus is on making it easier to debug and inspect organization, position, and role data by embedding structured log information in the DOM and providing a click handler to log this data in the console. Additionally, the Vite proxy configuration is removed for simplification.

**Admin logging improvements:**

* Added `positionId`, `roleId`, and `userId` fields to the `OrgPosition` and `OrgRole` types to support more detailed logging.
* Updated the rendering of positions and roles in the info panel to include a `data-admin-log` attribute with JSON-encoded details for each item. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL597-R613) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL609-R632)
* Updated the organization title in the info panel to include a `data-admin-log` attribute with JSON-encoded org details.
* Added a click event listener to the info panel that logs the parsed admin log data to the console when any item with `data-admin-log` is clicked.

**Build configuration:**

* Removed the Vite development server proxy configuration from `vite.config.ts` for a simpler setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin/debug click-to-log in the info panel and embedded metadata for org entries.
  * Organization views include optional identifiers for positions and roles.

* **Bug Fixes / Security**
  * HTML-escaped displayed org text, position/role text and avatars; mailto links URL-encoded; placeholder/loading text sanitized.

* **Chores**
  * Removed automatic dev-server proxy for org-chart; CI push trigger removed (manual dispatch only) and release workflow enhanced for Pages deployment.

* **Documentation**
  * README updated with release/GitHub Pages deployment steps and new default API base.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/F3-Nation/f3-org-map/pull/22)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->