### PR TITLE
feat: added helper text when org is selected that has no admin or edi…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -609,7 +609,7 @@ function renderInfo(org: Org, detail?: OrgInfo) {
           return `<li class="info-position">${avatarMarkup}<div><div class="info-role">${title}</div><div class="info-person">${name}</div></div></li>`
         })
         .join('')
-    : '<li class="info-empty">No roles listed.</li>'
+    : '<li class="info-empty">This organization has no admins. If you would like to take ownership of this organization, please fill out <a href="https://forms.gle/8AR4JCK3txSVr1Xy7" target="_blank" rel="noopener noreferrer">this form</a> and a Nation admin will get back to you.</li>'
 
   infoPanel.innerHTML = `
     <div class="info-title">${detail?.name ?? org.name}</div>


### PR DESCRIPTION
This pull request updates the message displayed when an organization has no admins, providing users with a clear call to action and a link to a form for taking ownership.

User experience improvements:

* Updated the empty state message in the organization info panel to inform users that the organization has no admins and included a link to a Google Form for requesting ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the message displayed when an organization has no admin roles, now directing users to request ownership via Google Form instead of showing generic text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/F3-Nation/f3-org-map/pull/25)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->