### PR TITLE
feat: make org hierarchy depth-agnostic ahead of the territory level

### DIFF
--- a/.features
+++ b/.features
@@ -5,20 +5,20 @@ Purpose
 
 Core Map Experience
 - Renders a Leaflet map with a light basemap and world copy jump.
-- Displays polygons for sectors, areas, and regions based on org data.
+- Displays polygons for sectors, territories, areas, and regions based on org data.
 - Uses convex hulls of active locations to define boundaries.
 - Uses a small circle buffer when an org has fewer than 3 points.
 - Shows a special star polygon for the International sector and General International Area.
 - Fits map bounds to visible org polygons or to a focused org when navigating.
 
 Navigation and Drill-Down
-- Layer buttons switch between sector, area, and region views.
+- Layer buttons switch between sector, territory, area, and region views.
 - Click on a polygon drills down to the next org level (regions are view-only).
 - Breadcrumbs show the current path and allow jump-back navigation.
 - Clicking Nation breadcrumb resets to sector view and shows Nation info.
 
 Search
-- Fuzzy search across sectors, areas, and regions.
+- Fuzzy search across sectors, territories, areas, and regions.
 - Search results show top matches and org type labels.
 - Enter selects the top match, click selects a specific match.
 - Search results close on Escape or outside click.
@@ -27,7 +27,7 @@ Org Information Panel
 - Shows org name and org type.
 - Shows org email with mailto link when available.
 - Shows social links (website, X/Twitter, Facebook, Instagram) when available.
-- Shows counts for sectors, areas, regions, events, AOs, and locations.
+- Shows counts for sectors, territories, areas, regions, events, AOs, and locations.
 - Shows region footprint in square miles when region boundary is available.
 - Shows leadership positions with avatar, title, and F3 name.
 - Shows a help tooltip for position update guidance.

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -88,8 +88,18 @@ describe('convexHull', () => {
 describe('URL state helpers', () => {
   const nation: Org = { id: 1, name: 'Nation', orgType: 'nation', parentId: null }
   const sector: Org = { id: 10, name: 'Mid Atlantic', orgType: 'sector', parentId: 1 }
-  const area: Org = { id: 20, name: 'Carolinas', orgType: 'area', parentId: 10 }
+  const territory: Org = { id: 15, name: 'Southeast', orgType: 'territory', parentId: 10 }
+  const area: Org = { id: 20, name: 'Carolinas', orgType: 'area', parentId: 15 }
   const region: Org = { id: 30, name: 'Charlotte Metro', orgType: 'region', parentId: 20 }
+  const ao: Org = { id: 40, name: 'The Chariot', orgType: 'ao', parentId: 30 }
+  const orgById = new Map<number, Org>([
+    [1, nation],
+    [10, sector],
+    [15, territory],
+    [20, area],
+    [30, region],
+    [40, ao],
+  ])
 
   beforeEach(() => {
     selectedPath.length = 0
@@ -97,28 +107,43 @@ describe('URL state helpers', () => {
     window.history.replaceState(null, '', '/')
   })
 
-  it('writes level and org query params', () => {
-    selectedPath.push(sector, area)
-    setCurrentLevelIndex(2)
+  it('writes level and org query params using named levels', () => {
+    selectedPath.push(sector, territory, area)
+    setCurrentLevelIndex(3) // region, per the new sector/territory/area/region/ao order
 
     updateUrlState()
 
-    expect(window.location.search).toContain('level=2')
+    expect(window.location.search).toContain('level=region')
     expect(window.location.search).toContain('org=20')
   })
 
-  it('restores selected path from a region deep-link up to area', () => {
-    window.history.replaceState(null, '', '/?org=30&level=2')
-    const orgById = new Map<number, Org>([
-      [1, nation],
-      [10, sector],
-      [20, area],
-      [30, region],
-    ])
+  it('restores selected path from a region deep-link (named level) up to area', () => {
+    window.history.replaceState(null, '', '/?org=30&level=region')
 
     restoreStateFromUrl(orgById)
 
-    expect(currentLevelIndex).toBe(2)
-    expect(selectedPath.map((org) => org.id)).toEqual([10, 20])
+    expect(currentLevelIndex).toBe(3)
+    expect(selectedPath.map((org) => org.id)).toEqual([10, 15, 20])
+  })
+
+  it('interprets a legacy numeric level param against the pre-territory order', () => {
+    // Old links encoded level=2 to mean "region" under the 4-entry
+    // sector/area/region/ao order that predates territory.
+    window.history.replaceState(null, '', '/?org=30&level=2')
+
+    restoreStateFromUrl(orgById)
+
+    expect(currentLevelIndex).toBe(3)
+    expect(selectedPath.map((org) => org.id)).toEqual([10, 15, 20])
+  })
+
+  it('clamps the default level index for a deep-link to the last (leaf) level', () => {
+    // ao is the last entry in levelOrder; with no level param the "one level
+    // deeper than org type" default must clamp instead of going out of bounds.
+    window.history.replaceState(null, '', '/?org=40')
+
+    restoreStateFromUrl(orgById)
+
+    expect(currentLevelIndex).toBe(4)
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -413,6 +413,17 @@ function getFocusBounds(org: Org): L.LatLngBounds | undefined {
   return L.latLngBounds(points.map((point) => L.latLng(point.lat, point.lng)))
 }
 
+// Finds the next level at or after `startIndex` that actually has orgs under
+// `parent`. Levels like territory can be unpopulated for a given branch
+// during the gradual backend rollout, so a fixed `levelIndex + 1` can point
+// at an empty level and strand navigation there.
+function nextLevelIndexWithOrgs(parent: Org, startIndex: number): number {
+  for (let i = startIndex; i < levelOrder.length; i++) {
+    if (getOrgsAtLevel(levelOrder[i], parent).length > 0) return i
+  }
+  return startIndex
+}
+
 function navigateToOrg(org: Org) {
   const levelIndex = levelOrder.indexOf(org.orgType)
   if (levelIndex === -1) return
@@ -421,8 +432,9 @@ function navigateToOrg(org: Org) {
   selectedPath.push(...buildBreadcrumbPath(org, getOrgPath(org)))
 
   if (drillableTypes.includes(org.orgType)) {
-    // Drill into the next level: breadcrumb includes the selected org itself.
-    setCurrentLevelIndex(levelIndex + 1)
+    // Drill into the next level with children: breadcrumb includes the
+    // selected org itself.
+    setCurrentLevelIndex(nextLevelIndexWithOrgs(org, levelIndex + 1))
   } else {
     // View-only leaf (e.g. region): stay at this level and show siblings.
     setCurrentLevelIndex(levelIndex)
@@ -576,7 +588,7 @@ function renderInfo(org: Org, detail?: OrgInfo) {
     aoCount += metrics.aos
     locationsCount += metrics.locations
   })
-  const currentType = detail?.orgType ?? org.orgType
+  const currentType = normalizeOrgType(detail?.orgType) ?? org.orgType
   const currentRank = levelOrder.indexOf(currentType)
   const descendantCountsMarkup = layerButtonTypes
     .filter((type) => levelOrder.indexOf(type) > currentRank)
@@ -808,6 +820,8 @@ async function loadOrgInfo(org: Org) {
       const refreshedType = normalizeOrgType(data.orgType)
       if (refreshedType != null) {
         existing.orgType = refreshedType
+      } else {
+        console.warn(`Ignoring unrecognized orgType for org ${org.id}:`, data.orgType)
       }
     }
   } catch (error) {
@@ -861,14 +875,10 @@ function createCircleBuffer(
   return circle
 }
 
-function getCurrentLevelOrgs(): Org[] {
-  const level = levelOrder[currentLevelIndex]
-
+function getOrgsAtLevel(level: OrgType, parent: Org | undefined): Org[] {
   if (level === 'sector') {
     return [...orgById.values()].filter((org) => org.orgType === 'sector')
   }
-
-  const parent = selectedPath[selectedPath.length - 1]
 
   // If no parent selected, show all orgs of this level (for layer button views)
   if (!parent) {
@@ -897,6 +907,10 @@ function getCurrentLevelOrgs(): Org[] {
   }
 
   return [...orgById.values()].filter((org) => org.orgType === level && org.parentId === parent.id)
+}
+
+function getCurrentLevelOrgs(): Org[] {
+  return getOrgsAtLevel(levelOrder[currentLevelIndex], selectedPath[selectedPath.length - 1])
 }
 
 function renderBreadcrumb() {
@@ -928,12 +942,16 @@ function renderBreadcrumb() {
         displayNationInfo()
       } else {
         selectedPath.length = depth + 1
-        setCurrentLevelIndex(depth + 1)
+        const org = selectedPath[depth]
+        if (!org) return
+        // Derive the level from the clicked org's actual type rather than its
+        // position in the breadcrumb: once a hierarchy level (e.g. territory)
+        // can be missing for a given org, `selectedPath` and `levelOrder`
+        // are no longer guaranteed to stay positionally aligned.
+        setCurrentLevelIndex(levelOrder.indexOf(org.orgType) + 1)
         updateUrlState()
         renderLevel()
-        // Show info for the org at this breadcrumb (by depth)
-        const org = selectedPath[depth]
-        if (org) loadOrgInfo(org)
+        loadOrgInfo(org)
       }
     })
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   buildOrgHierarchy,
   getOrgPointsFromItem,
   normalizeOrgType,
+  ORG_TYPE_PLURAL,
   type Org,
   type OrgChartItem,
   type OrgType,
@@ -19,6 +20,9 @@ import {
   updateUrlState,
   restoreStateFromUrl,
   levelOrder,
+  layerButtonTypes,
+  drillableTypes,
+  buildBreadcrumbPath,
   currentLevelIndex,
   selectedPath,
   setCurrentLevelIndex,
@@ -60,17 +64,27 @@ if (!app) {
   throw new Error('Missing #app container')
 }
 
+const brandSubtitle = levelOrder.map((type) => ORG_TYPE_PLURAL[type]).join(' → ')
+const layerButtonsHtml = layerButtonTypes
+  .map((type) => {
+    const levelIndex = levelOrder.indexOf(type)
+    const activeClass = levelIndex === 0 ? ' layer-active' : ''
+    return `<button class="layer-btn${activeClass}" data-level="${levelIndex}">${ORG_TYPE_PLURAL[type]}</button>`
+  })
+  .join('\n        ')
+const searchPlaceholder = `Search ${layerButtonTypes
+  .map((type) => ORG_TYPE_PLURAL[type].toLowerCase())
+  .join(', ')}`
+
 app.innerHTML = `
   <div class="app">
     <header class="top-bar">
       <div class="brand">
         <div class="brand-title">F3 Geographic Directory</div>
-        <div class="brand-subtitle">Sectors → Areas → Regions → AOs</div>
+        <div class="brand-subtitle">${brandSubtitle}</div>
       </div>
       <div class="layers" id="layers">
-        <button class="layer-btn layer-active" data-level="0">Sectors</button>
-        <button class="layer-btn" data-level="1">Areas</button>
-        <button class="layer-btn" data-level="2">Regions</button>
+        ${layerButtonsHtml}
       </div>
       <div class="controls">
         <div id="breadcrumb" class="breadcrumb"></div>
@@ -98,7 +112,7 @@ app.innerHTML = `
             id="org-search"
             class="search-input"
             type="search"
-            placeholder="Search sectors, areas, regions"
+            placeholder="${searchPlaceholder}"
             autocomplete="off"
             disabled
           />
@@ -403,27 +417,14 @@ function navigateToOrg(org: Org) {
   const levelIndex = levelOrder.indexOf(org.orgType)
   if (levelIndex === -1) return
 
-  if (org.orgType === 'sector') {
-    selectedPath.length = 0
-    selectedPath.push(org)
-    setCurrentLevelIndex(1) // Switch to area layer
-  } else if (org.orgType === 'area') {
-    const path = getOrgPath(org).filter((item) => item.orgType !== 'nation')
-    selectedPath.length = 0
-    selectedPath.push(...path)
-    setCurrentLevelIndex(2) // Switch to region layer
-  } else if (org.orgType === 'region') {
-    // Only show up to area in breadcrumb, not region itself
-    const path = getOrgPath(org).filter(
-      (item) => item.orgType !== 'nation' && item.orgType !== 'region',
-    )
-    selectedPath.length = 0
-    selectedPath.push(...path)
-    setCurrentLevelIndex(levelIndex)
+  selectedPath.length = 0
+  selectedPath.push(...buildBreadcrumbPath(org, getOrgPath(org)))
+
+  if (drillableTypes.includes(org.orgType)) {
+    // Drill into the next level: breadcrumb includes the selected org itself.
+    setCurrentLevelIndex(levelIndex + 1)
   } else {
-    const path = getOrgPath(org).filter((item) => item.orgType !== 'nation')
-    selectedPath.length = 0
-    selectedPath.push(...path.slice(0, -1))
+    // View-only leaf (e.g. region): stay at this level and show siblings.
     setCurrentLevelIndex(levelIndex)
   }
 
@@ -575,17 +576,20 @@ function renderInfo(org: Org, detail?: OrgInfo) {
     aoCount += metrics.aos
     locationsCount += metrics.locations
   })
-  const sectorCount = descendantOrgs.filter((item) => item.orgType === 'sector').length
-  const areaCount = descendantOrgs.filter((item) => item.orgType === 'area').length
-  const regionCount = descendantOrgs.filter((item) => item.orgType === 'region').length
-  const formattedAreaCount = formatNumber(areaCount)
-  const formattedRegionCount = formatNumber(regionCount)
-  const formattedSectorCount = formatNumber(sectorCount)
+  const currentType = detail?.orgType ?? org.orgType
+  const currentRank = levelOrder.indexOf(currentType)
+  const descendantCountsMarkup = layerButtonTypes
+    .filter((type) => levelOrder.indexOf(type) > currentRank)
+    .map((type) => {
+      const count = descendantOrgs.filter((item) => item.orgType === type).length
+      return `<div>${ORG_TYPE_PLURAL[type]}: ${formatNumber(count)}</div>`
+    })
+    .join('')
   const formattedAoCount = formatNumber(aoCount)
   const formattedEventsCount = formatNumber(eventsCount)
   const formattedLocationsCount = formatNumber(locationsCount)
   let regionFootprint: number | null = null
-  if ((detail?.orgType ?? org.orgType) === 'region') {
+  if (currentType === 'region') {
     const regionPoints = getOrgPoints(org)
     if (regionPoints.length >= 3) {
       const hull = convexHull(regionPoints)
@@ -670,8 +674,8 @@ function renderInfo(org: Org, detail?: OrgInfo) {
     : '<li class="info-empty">This organization has no admins. If you would like to take ownership of this organization, please fill out <a href="https://forms.gle/8AR4JCK3txSVr1Xy7" target="_blank" rel="noopener noreferrer">this form</a> and a Nation admin will get back to you.</li>'
 
   const displayName = escapeHtml(detail?.name ?? org.name)
-  const displayOrgType = escapeHtml((detail?.orgType ?? org.orgType).toUpperCase())
-  const orgAdminLogAttr = ` data-admin-log="${encodeAdminLog({ orgId: detail?.id ?? org.id, name: detail?.name ?? org.name, orgType: detail?.orgType ?? org.orgType })}"`
+  const displayOrgType = escapeHtml(currentType.toUpperCase())
+  const orgAdminLogAttr = ` data-admin-log="${encodeAdminLog({ orgId: detail?.id ?? org.id, name: detail?.name ?? org.name, orgType: currentType })}"`
 
   infoPanel.innerHTML = `
     <div class="info-title"${orgAdminLogAttr}>${displayName}</div>
@@ -684,9 +688,7 @@ function renderInfo(org: Org, detail?: OrgInfo) {
     <div class="info-section">
       <div class="info-label">Counts</div>
       <div class="info-value">
-        ${(detail?.orgType ?? org.orgType) === 'nation' ? `<div>Sectors: ${formattedSectorCount}</div>` : ''}
-        ${(detail?.orgType ?? org.orgType) === 'nation' || (detail?.orgType ?? org.orgType) === 'sector' ? `<div>Areas: ${formattedAreaCount}</div>` : ''}
-        ${(detail?.orgType ?? org.orgType) === 'nation' || (detail?.orgType ?? org.orgType) === 'sector' || (detail?.orgType ?? org.orgType) === 'area' ? `<div>Regions: ${formattedRegionCount}</div>` : ''}
+        ${descendantCountsMarkup}
         <div>Events: ${formattedEventsCount}</div>
         <div>AOs: ${formattedAoCount}</div>
         <div>Locations: ${formattedLocationsCount}</div>
@@ -803,7 +805,10 @@ async function loadOrgInfo(org: Org) {
     const existing = orgById.get(org.id)
     if (existing) {
       existing.name = data.name ?? existing.name
-      existing.orgType = normalizeOrgType(data.orgType, existing.orgType)
+      const refreshedType = normalizeOrgType(data.orgType)
+      if (refreshedType != null) {
+        existing.orgType = refreshedType
+      }
     }
   } catch (error) {
     if (activeInfoOrgId === org.id) {
@@ -870,11 +875,16 @@ function getCurrentLevelOrgs(): Org[] {
     return [...orgById.values()].filter((org) => org.orgType === level)
   }
 
-  // Special handling for International: get all region descendants (not just direct children)
-  if (isSectorInternational(parent) && level === 'region') {
+  // Special handling for International: get all territory/area/region
+  // descendants (not just direct children), since International's structure
+  // doesn't nest cleanly through area.
+  if (
+    isSectorInternational(parent) &&
+    (level === 'territory' || level === 'area' || level === 'region')
+  ) {
     const internationalDescendants = getDescendantOrgIds(parent.id)
     return [...orgById.values()].filter(
-      (org) => org.orgType === 'region' && internationalDescendants.includes(org.id),
+      (org) => org.orgType === level && internationalDescendants.includes(org.id),
     )
   }
 
@@ -985,7 +995,7 @@ function renderLevel(focusBounds?: L.LatLngBounds) {
       polygon.setStyle({ weight: 3, fillOpacity: 0.28 })
       loadOrgInfo(org)
       // If at region level, update URL to reflect hovered region
-      if (currentLevelIndex === 2) {
+      if (levelOrder[currentLevelIndex] === 'region') {
         selectedPath.length = 0
         selectedPath.push(org)
         updateUrlState()
@@ -997,8 +1007,8 @@ function renderLevel(focusBounds?: L.LatLngBounds) {
     })
 
     polygon.on('click', () => {
-      // Regions are view-only, don't navigate on click
-      if (org.orgType === 'region') return
+      // View-only leaves (e.g. region) don't navigate on click
+      if (!drillableTypes.includes(org.orgType)) return
       if (currentLevelIndex >= levelOrder.length - 1) return
       navigateToOrg(org)
     })
@@ -1013,7 +1023,7 @@ function renderLevel(focusBounds?: L.LatLngBounds) {
   }
 
   if (orgs.length === 0) {
-    renderPlaceholder(`No ${level}s available.`)
+    renderPlaceholder(`No ${ORG_TYPE_PLURAL[level].toLowerCase()} available.`)
   }
 }
 
@@ -1032,9 +1042,7 @@ async function init() {
     orgById.set(org.id, org)
   })
 
-  searchIndex = orgs.filter(
-    (org) => org.orgType === 'sector' || org.orgType === 'area' || org.orgType === 'region',
-  )
+  searchIndex = orgs.filter((org) => layerButtonTypes.includes(org.orgType))
   searchInput.disabled = false
 
   items.forEach((item) => {
@@ -1072,9 +1080,8 @@ async function init() {
   // Check if we should zoom to a region and show its info
   const params = new URLSearchParams(window.location.search)
   const orgParam = params.get('org')
-  const levelParam = params.get('level')
   let zoomed = false
-  if (levelParam === '2' && orgParam) {
+  if (orgParam && levelOrder[currentLevelIndex] === 'region') {
     const orgId = parseInt(orgParam, 10)
     const org = orgById.get(orgId)
     if (org && org.orgType === 'region') {

--- a/src/orgChart.test.ts
+++ b/src/orgChart.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { buildOrgHierarchy, normalizeOrgType, type OrgChartItem } from './orgChart'
+
+describe('normalizeOrgType', () => {
+  it('recognizes every current org type, case- and whitespace-insensitively', () => {
+    expect(normalizeOrgType(' Territory ')).toBe('territory')
+    expect(normalizeOrgType('REGION')).toBe('region')
+  })
+
+  it('returns null for unrecognized input instead of guessing a plausible type', () => {
+    expect(normalizeOrgType('district')).toBeNull()
+    expect(normalizeOrgType(undefined)).toBeNull()
+    expect(normalizeOrgType(42)).toBeNull()
+  })
+})
+
+describe('buildOrgHierarchy', () => {
+  it('keeps territory as its own type and does not shift ancestor types in a six-level hierarchy', () => {
+    const items: OrgChartItem[] = [
+      {
+        id: 30,
+        name: 'Charlotte Metro',
+        orgType: 'region',
+        hierarchy: [
+          [20, 'Carolinas', 'area'],
+          [15, 'Southeast', 'territory'],
+          [10, 'Mid Atlantic', 'sector'],
+          [1, 'Nation', 'nation'],
+        ],
+      },
+    ]
+
+    const orgs = buildOrgHierarchy(items)
+    const byId = new Map(orgs.map((org) => [org.id, org]))
+
+    expect(byId.get(30)).toMatchObject({ orgType: 'region', parentId: 20 })
+    expect(byId.get(20)).toMatchObject({ orgType: 'area', parentId: 15 })
+    expect(byId.get(15)).toMatchObject({ orgType: 'territory', parentId: 10 })
+    expect(byId.get(10)).toMatchObject({ orgType: 'sector', parentId: 1 })
+    expect(byId.get(1)).toMatchObject({ orgType: 'nation', parentId: null })
+  })
+
+  it('skips an item whose own org type is unrecognized rather than mislabeling it', () => {
+    const items: OrgChartItem[] = [
+      { id: 99, name: 'Mystery Org', orgType: 'district' as OrgChartItem['orgType'] },
+    ]
+
+    expect(buildOrgHierarchy(items)).toEqual([])
+  })
+
+  it('skips a hierarchy-tuple ancestor with an unrecognized type without dropping other ancestors', () => {
+    const items: OrgChartItem[] = [
+      {
+        id: 30,
+        name: 'Charlotte Metro',
+        orgType: 'region',
+        hierarchy: [
+          [20, 'Carolinas', 'district'],
+          [10, 'Mid Atlantic', 'sector'],
+        ],
+      },
+    ]
+
+    const orgs = buildOrgHierarchy(items)
+    const byId = new Map(orgs.map((org) => [org.id, org]))
+
+    expect(byId.has(20)).toBe(false)
+    expect(byId.get(10)).toMatchObject({ orgType: 'sector' })
+  })
+
+  it('skips legacy bare-number hierarchy entries instead of positionally guessing their type', () => {
+    const items: OrgChartItem[] = [
+      { id: 30, name: 'Charlotte Metro', orgType: 'region', hiearchy: [20, 10, 1] },
+    ]
+
+    expect(buildOrgHierarchy(items)).toEqual([
+      { id: 30, name: 'Charlotte Metro', orgType: 'region', parentId: 20 },
+    ])
+  })
+})

--- a/src/orgChart.test.ts
+++ b/src/orgChart.test.ts
@@ -66,6 +66,8 @@ describe('buildOrgHierarchy', () => {
 
     expect(byId.has(20)).toBe(false)
     expect(byId.get(10)).toMatchObject({ orgType: 'sector' })
+    // The child must not be left pointing at the skipped, never-created ancestor.
+    expect(byId.get(30)).toMatchObject({ parentId: null })
   })
 
   it('skips legacy bare-number hierarchy entries instead of positionally guessing their type', () => {

--- a/src/orgChart.ts
+++ b/src/orgChart.ts
@@ -1,4 +1,14 @@
-export type OrgType = 'nation' | 'sector' | 'area' | 'region' | 'ao'
+export const ORG_TYPES = ['ao', 'region', 'area', 'territory', 'sector', 'nation'] as const
+export type OrgType = (typeof ORG_TYPES)[number]
+
+export const ORG_TYPE_PLURAL: Record<OrgType, string> = {
+  nation: 'Nation',
+  sector: 'Sectors',
+  territory: 'Territories',
+  area: 'Areas',
+  region: 'Regions',
+  ao: 'AOs',
+}
 
 export type Org = {
   id: number
@@ -34,19 +44,10 @@ export type OrgChartItem = {
 
 export type Point = { lat: number; lng: number }
 
-export function normalizeOrgType(value: unknown, fallback: OrgType): OrgType {
-  if (typeof value !== 'string') return fallback
+export function normalizeOrgType(value: unknown): OrgType | null {
+  if (typeof value !== 'string') return null
   const normalized = value.trim().toLowerCase()
-  if (
-    normalized === 'nation' ||
-    normalized === 'sector' ||
-    normalized === 'area' ||
-    normalized === 'region' ||
-    normalized === 'ao'
-  ) {
-    return normalized as OrgType
-  }
-  return fallback
+  return (ORG_TYPES as readonly string[]).includes(normalized) ? (normalized as OrgType) : null
 }
 
 export function getOrgParentId(item: OrgChartItem): number | null {
@@ -95,7 +96,6 @@ export function getOrgPointsFromItem(item: OrgChartItem): Point[] {
 
 export function buildOrgHierarchy(items: OrgChartItem[]): Org[] {
   const orgMap = new Map<number, Org>()
-  const hierarchyTypes: OrgType[] = ['area', 'sector', 'nation']
 
   const ensureOrg = (id: number, orgType: OrgType, name?: string, parentId?: number | null) => {
     const existing = orgMap.get(id)
@@ -120,26 +120,36 @@ export function buildOrgHierarchy(items: OrgChartItem[]): Org[] {
     const itemId = item.id ?? item.orgId
     if (itemId == null) return
     const parentId = getOrgParentId(item)
-    const orgType = normalizeOrgType(item.orgType, 'region')
-    ensureOrg(itemId, orgType, item.name, parentId ?? null)
+    const orgType = normalizeOrgType(item.orgType)
+    if (orgType != null) {
+      ensureOrg(itemId, orgType, item.name, parentId ?? null)
+    } else {
+      console.warn(`Skipping org ${itemId} with unrecognized orgType:`, item.orgType)
+    }
 
     const hierarchy = item.hierarchy ?? item.hiearchy
     if (Array.isArray(hierarchy)) {
       hierarchy.forEach((entry, index) => {
-        if (Array.isArray(entry)) {
-          const [parentOrgId, parentName, parentTypeRaw] = entry
-          const parentType = normalizeOrgType(parentTypeRaw, hierarchyTypes[index] ?? 'nation')
-          const nextEntry = hierarchy[index + 1]
-          const parentParentId = Array.isArray(nextEntry) ? nextEntry[0] : (nextEntry ?? null)
-          ensureOrg(parentOrgId, parentType, parentName, parentParentId)
+        // Legacy bare-number hierarchy entries carry no type string at all.
+        // A positional guess is unreliable once more levels can sit between
+        // the leaf and nation, so skip rather than mislabel.
+        if (!Array.isArray(entry)) {
+          console.warn(`Skipping legacy bare-number hierarchy ancestor for org ${itemId}:`, entry)
           return
         }
 
-        const parentOrgId = entry
-        const parentType = hierarchyTypes[index] ?? 'nation'
+        const [parentOrgId, parentName, parentTypeRaw] = entry
+        const parentType = normalizeOrgType(parentTypeRaw)
+        if (parentType == null) {
+          console.warn(
+            `Skipping hierarchy ancestor ${parentOrgId} with unrecognized orgType:`,
+            parentTypeRaw,
+          )
+          return
+        }
         const nextEntry = hierarchy[index + 1]
         const parentParentId = Array.isArray(nextEntry) ? nextEntry[0] : (nextEntry ?? null)
-        ensureOrg(parentOrgId, parentType, parentOrgId === 1 ? 'Nation' : undefined, parentParentId)
+        ensureOrg(parentOrgId, parentType, parentName, parentParentId)
       })
     }
   })

--- a/src/orgChart.ts
+++ b/src/orgChart.ts
@@ -1,3 +1,6 @@
+// Leaf-to-root order (ao → nation). src/state.ts reverses this to derive
+// root-to-leaf navigation order — insert a new level here in the position
+// matching its place in the real hierarchy.
 export const ORG_TYPES = ['ao', 'region', 'area', 'territory', 'sector', 'nation'] as const
 export type OrgType = (typeof ORG_TYPES)[number]
 
@@ -56,7 +59,11 @@ export function getOrgParentId(item: OrgChartItem): number | null {
   if (Array.isArray(hierarchy) && hierarchy.length > 0) {
     const first = hierarchy[0]
     if (Array.isArray(first)) {
-      return first[0] ?? null
+      // Only point at this ancestor if it will actually be created below —
+      // an unrecognized type means it gets skipped, so referencing its id
+      // here would leave a dangling parentId. Treat the item as a root
+      // instead of guessing which further ancestor should stand in for it.
+      return normalizeOrgType(first[2]) != null ? (first[0] ?? null) : null
     }
     return first ?? null
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -13,8 +13,8 @@ export const levelOrder: OrgType[] = [...ORG_TYPES].filter((type) => type !== 'n
 export const layerButtonTypes: OrgType[] = levelOrder.filter((type) => type !== 'ao')
 
 // Levels where selecting an org advances the drill-down to the next level.
-// The last layer-button level (region) is a view-only leaf: it stays at its
-// own level and shows siblings instead.
+// Whichever type is last in `layerButtonTypes` (currently region) is a
+// view-only leaf: it stays at its own level and shows siblings instead.
 export const drillableTypes: OrgType[] = layerButtonTypes.slice(0, -1)
 
 // Pre-territory URL '?level=N' encoding, kept only to interpret old bookmarked

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,17 +2,53 @@ export function setCurrentLevelIndex(val: number) {
   currentLevelIndex = val
 }
 // State logic extracted from main.ts
-import type { Org, OrgType } from './orgChart'
+import { normalizeOrgType, ORG_TYPES, type Org, type OrgType } from './orgChart'
 
-export const levelOrder: OrgType[] = ['sector', 'area', 'region', 'ao']
+// Root-to-leaf navigation order, derived from the single ORG_TYPES source of
+// truth so inserting a new level there is the only change this file needs.
+export const levelOrder: OrgType[] = [...ORG_TYPES].filter((type) => type !== 'nation').reverse()
+
+// Levels that get a layer button, are searchable, and show an info-panel
+// count. 'ao' is deliberately excluded: it has no button/search entry today.
+export const layerButtonTypes: OrgType[] = levelOrder.filter((type) => type !== 'ao')
+
+// Levels where selecting an org advances the drill-down to the next level.
+// The last layer-button level (region) is a view-only leaf: it stays at its
+// own level and shows siblings instead.
+export const drillableTypes: OrgType[] = layerButtonTypes.slice(0, -1)
+
+// Pre-territory URL '?level=N' encoding, kept only to interpret old bookmarked
+// links against the order they were generated under.
+const LEGACY_LEVEL_ORDER: OrgType[] = ['sector', 'area', 'region', 'ao']
+
 export let currentLevelIndex = 0
 export let selectedPath: Org[] = []
+
+// Breadcrumb-visible ancestors for `org`, given its root-to-leaf `path`
+// (including `org` itself and nation): nation is always excluded, and a
+// view-only leaf (e.g. region) also excludes itself.
+export function buildBreadcrumbPath(org: Org, path: Org[]): Org[] {
+  return path.filter(
+    (item) =>
+      item.orgType !== 'nation' &&
+      (drillableTypes.includes(org.orgType) || item.orgType !== org.orgType),
+  )
+}
+
+function parseLevelParam(levelParam: string): number {
+  if (/^\d+$/.test(levelParam)) {
+    const legacyType = LEGACY_LEVEL_ORDER[parseInt(levelParam, 10)]
+    return legacyType ? Math.max(levelOrder.indexOf(legacyType), 0) : 0
+  }
+  const normalized = normalizeOrgType(levelParam)
+  return normalized ? Math.max(levelOrder.indexOf(normalized), 0) : 0
+}
 
 export function updateUrlState() {
   const params = new URLSearchParams()
   // Only add level if not 0 (root)
   if (currentLevelIndex > 0) {
-    params.set('level', String(currentLevelIndex))
+    params.set('level', levelOrder[currentLevelIndex])
   }
   if (selectedPath.length > 0) {
     const lastOrg = selectedPath[selectedPath.length - 1]
@@ -37,26 +73,21 @@ export function restoreStateFromUrl(orgById?: Map<number, Org>) {
         current = current.parentId ? orgById.get(current.parentId) : undefined
       }
       selectedPath.length = 0
-      // If org is a region, only include up to area in selectedPath
-      if (org.orgType === 'region') {
-        selectedPath.push(...path.filter((o) => o.orgType !== 'nation' && o.orgType !== 'region'))
-      } else {
-        selectedPath.push(...path.filter((o) => o.orgType !== 'nation'))
-      }
+      selectedPath.push(...buildBreadcrumbPath(org, path))
       if (levelParam) {
-        setCurrentLevelIndex(parseInt(levelParam, 10))
+        setCurrentLevelIndex(parseLevelParam(levelParam))
       } else {
-        // Default: go one level deeper than org type
+        // Default: go one level deeper than org type, clamped to the last level
         const levelIndex = levelOrder.indexOf(org.orgType)
         if (levelIndex !== -1) {
-          setCurrentLevelIndex(levelIndex + 1)
+          setCurrentLevelIndex(Math.min(levelIndex + 1, levelOrder.length - 1))
         }
       }
       return
     }
   }
   if (levelParam) {
-    setCurrentLevelIndex(parseInt(levelParam, 10))
+    setCurrentLevelIndex(parseLevelParam(levelParam))
     selectedPath.length = 0
   } else {
     setCurrentLevelIndex(0)


### PR DESCRIPTION
## Summary

F3's org hierarchy is gaining a sixth level, **territory**, between sector and area (`nation → sector → territory → area → region → AO`). Today this app hardcodes a five-level hierarchy in several places and, worse, silently coerces an unrecognized org type into a *plausible but wrong* one instead of failing loudly — a truncated `hierarchy` positional array would mislabel a territory as a sector or area with nothing thrown and nothing logged.

This PR makes the hierarchy depth-agnostic so it survives territory's insertion (and the next level after that) without further hardcoding:

- `ORG_TYPES` (in `src/orgChart.ts`) is now the single ordered source of truth `OrgType` derives from. `levelOrder`, `layerButtonTypes`, and `drillableTypes` (in `src/state.ts`) are all derived from it instead of duplicated as separate positional arrays.
- `normalizeOrgType` now returns `OrgType | null` instead of silently falling back to a caller-supplied guess. `buildOrgHierarchy` trusts each hierarchy tuple's own `orgType` string and skips (with a `console.warn`) anything it can't recognize — including legacy bare-number `hierarchy`/`hiearchy` entries, which carry no type info and were previously assigned a type purely by array position.
- Layer buttons, the subtitle, the search placeholder, and the info-panel descendant counts in `src/main.ts` are now generated from that config instead of hardcoded per-level branches and a growing ternary chain.
- `?level=` URL state now writes a named level (e.g. `level=region`) and still reads old numeric links, remapped against the pre-territory 4-level order, so existing bookmarks/shared links keep resolving to the correct level.
- Fixed a latent out-of-bounds crash: deep-linking directly to an `ao` org with no `level` param would compute an index one past the end of `levelOrder`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (Biome) — clean
- [x] `npm run build` — clean
- [x] `npx vitest run` — 17/17 passing, including new `src/orgChart.test.ts` coverage (six-level hierarchy fixture, `normalizeOrgType` null-handling, legacy hierarchy skipping) and updated `src/main.test.ts` URL-state coverage (named levels, legacy numeric levels, AO-clamp regression)
- [x] Verified in-browser against the real production API (`api.f3nation.com`, 551 live orgs): Territories button/subtitle/search-placeholder render correctly, drill-down correctly advances sector → territory (not the old off-by-one into area), info-panel counts are correct at each level, and both named and legacy-numeric `?level=` deep links resolve to the correct level

Fixes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added territory-level support across organization maps and hierarchy navigation.
  * Added layer switching, territory-aware breadcrumbs, and fuzzy search.
  * Organization information now includes territory counts.
  * Deep links support named hierarchy levels while retaining compatibility with legacy numeric links.
  * Improved handling of invalid organization data and default navigation levels.

* **Documentation**
  * Updated feature documentation to cover territory polygons, navigation, layer switching, and fuzzy search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->